### PR TITLE
[WIP] [DO NOT MERGE]- Start berllatrix fork from slot 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ genesis.ssz
 venv
 
 *.ssz
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv
 
 *.ssz
 .idea
+eth2-testnet-genesis

--- a/migrate_bin.sh
+++ b/migrate_bin.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+go build
+rm -f $HOME/Workspace/lukso/network-deployment/kintsugi/bin/eth2-testnet-genesis
+cp eth2-testnet-genesis $HOME/Workspace/lukso/network-deployment/kintsugi/bin/eth2-testnet-genesis


### PR DESCRIPTION
### What does this PR do? Why is it needed?
Currently kintsugi does have support to start validators from genesis epoch but they don't have any support to withdraw those validator's balance from geth or execution engine. If we initiase those genesis validator's deposits into contract's storage in geth's genesis.json file then we can not add any new validator using deposit contract further.